### PR TITLE
Command to allow the user to buy more effects

### DIFF
--- a/src/buttonEvents/Effects.ts
+++ b/src/buttonEvents/Effects.ts
@@ -3,6 +3,7 @@ import { ButtonEvent } from "../type/buttonEvent";
 import List from "./Effects/List";
 import Use from "./Effects/Use";
 import AppLogger from "../client/appLogger";
+import Buy from "./Effects/Buy";
 
 export default class Effects extends ButtonEvent {
     public override async execute(interaction: ButtonInteraction) {
@@ -14,6 +15,9 @@ export default class Effects extends ButtonEvent {
                 break;
             case "use":
                 await Use.Execute(interaction);
+                break;
+            case "buy":
+                await Buy.Execute(interaction);
                 break;
             default:
                 AppLogger.LogError("Buttons/Effects", `Unknown action, ${action}`);

--- a/src/buttonEvents/Effects/Buy.ts
+++ b/src/buttonEvents/Effects/Buy.ts
@@ -1,0 +1,25 @@
+import {ButtonInteraction} from "discord.js";
+import AppLogger from "../../client/appLogger";
+
+export default class Buy {
+    public static async Execute(interaction: ButtonInteraction) {
+        const subaction = interaction.customId.split(" ")[2];
+
+        switch (subaction) {
+            case "confirm":
+                await this.Confirm(interaction);
+                break;
+            case "cancel":
+                await this.Cancel(interaction);
+                break;
+            default:
+                AppLogger.LogError("Buy", `Unknown subaction, effects ${subaction}`);
+        }
+    }
+
+    private static async Confirm(interaction: ButtonInteraction) {
+    }
+
+    private static async Cancel(interaction: ButtonInteraction) {
+    }
+}

--- a/src/buttonEvents/Effects/Buy.ts
+++ b/src/buttonEvents/Effects/Buy.ts
@@ -1,5 +1,7 @@
 import {ButtonInteraction} from "discord.js";
 import AppLogger from "../../client/appLogger";
+import EffectHelper from "../../helpers/EffectHelper";
+import EmbedColours from "../../constants/EmbedColours";
 
 export default class Buy {
     public static async Execute(interaction: ButtonInteraction) {
@@ -18,6 +20,35 @@ export default class Buy {
     }
 
     private static async Confirm(interaction: ButtonInteraction) {
+        const id = interaction.customId.split(" ")[3];
+        const quantity = interaction.customId.split(" ")[4];
+
+        if (!id || !quantity) {
+            AppLogger.LogError("Buy Confirm", "Not enough parameters");
+            return;
+        }
+
+        const quantityNumber = Number(quantity);
+        
+        if (!quantityNumber || quantityNumber < 1) {
+            AppLogger.LogError("Buy Confirm", "Invalid number");
+            return;
+        }
+
+        const generatedEmbed = await EffectHelper.GenerateEffectBuyEmbed(interaction.user.id, id, quantityNumber, true);
+
+        if (typeof generatedEmbed == "string") {
+            await interaction.reply(generatedEmbed);
+            return;
+        }
+
+        generatedEmbed.embed.setColor(EmbedColours.Success);
+        generatedEmbed.embed.setFooter({ text: "Purchased" });
+
+        await interaction.update({
+            embeds: [ generatedEmbed.embed ],
+            components: [ generatedEmbed.row ],
+        });
     }
 
     private static async Cancel(interaction: ButtonInteraction) {

--- a/src/buttonEvents/Effects/Buy.ts
+++ b/src/buttonEvents/Effects/Buy.ts
@@ -80,5 +80,41 @@ export default class Buy {
     }
 
     private static async Cancel(interaction: ButtonInteraction) {
+        const id = interaction.customId.split(" ")[3];
+        const quantity = interaction.customId.split(" ")[4];
+
+        if (!id || !quantity) {
+            AppLogger.LogError("Buy Cancel", "Not enough parameters");
+            return;
+        }
+        
+        const effectDetail = EffectDetails.get(id);
+
+        if (!effectDetail) {
+            AppLogger.LogError("Buy Cancel", "Effect detail not found!");
+            return;
+        }
+
+        const quantityNumber = Number(quantity);
+        
+        if (!quantityNumber || quantityNumber < 1) {
+            AppLogger.LogError("Buy Cancel", "Invalid number");
+            return;
+        }
+
+        const generatedEmbed = await EffectHelper.GenerateEffectBuyEmbed(interaction.user.id, id, quantityNumber, true);
+
+        if (typeof generatedEmbed == "string") {
+            await interaction.reply(generatedEmbed);
+            return;
+        }
+
+        generatedEmbed.embed.setColor(EmbedColours.Error);
+        generatedEmbed.embed.setFooter({ text: "Cancelled" });
+
+        await interaction.update({
+            embeds: [ generatedEmbed.embed ],
+            components: [ generatedEmbed.row ],
+        });
     }
 }

--- a/src/buttonEvents/Effects/List.ts
+++ b/src/buttonEvents/Effects/List.ts
@@ -11,7 +11,7 @@ export default async function List(interaction: ButtonInteraction) {
         return;
     }
 
-    const result = await EffectHelper.GenerateEffectEmbed(interaction.user.id, page);
+    const result = await EffectHelper.GenerateEffectListEmbed(interaction.user.id, page);
 
     await interaction.update({
         embeds: [ result.embed ],

--- a/src/commands/effects/Buy.ts
+++ b/src/commands/effects/Buy.ts
@@ -1,0 +1,4 @@
+import { CommandInteraction } from "discord.js";
+
+export default async function Buy(interaction: CommandInteraction) {
+}

--- a/src/commands/effects/Buy.ts
+++ b/src/commands/effects/Buy.ts
@@ -1,4 +1,22 @@
 import { CommandInteraction } from "discord.js";
+import EffectHelper from "../../helpers/EffectHelper";
 
 export default async function Buy(interaction: CommandInteraction) {
+    const id = interaction.options.get("id", true).value!;
+    const quantity = interaction.options.get("quantity")?.value ?? 1;
+
+    const idValue = id.toString();
+    const quantityValue = Number(quantity);
+
+    const result = await EffectHelper.GenerateEffectBuyEmbed(interaction.user.id, idValue, quantityValue, false);
+
+    if (typeof result == "string") {
+        await interaction.reply(result);
+        return;
+    }
+
+    await interaction.reply({
+        embeds: [ result.embed ],
+        components: [ result.row ],
+    });
 }

--- a/src/commands/effects/List.ts
+++ b/src/commands/effects/List.ts
@@ -6,7 +6,7 @@ export default async function List(interaction: CommandInteraction) {
 
     const page = !isNaN(Number(pageOption?.value)) ? Number(pageOption?.value) : 1;
 
-    const result = await EffectHelper.GenerateEffectEmbed(interaction.user.id, page);
+    const result = await EffectHelper.GenerateEffectListEmbed(interaction.user.id, page);
 
     await interaction.reply({
         embeds: [ result.embed ],

--- a/src/commands/effects/List.ts
+++ b/src/commands/effects/List.ts
@@ -1,0 +1,15 @@
+import { CommandInteraction } from "discord.js";
+import EffectHelper from "../../helpers/EffectHelper";
+
+export default async function List(interaction: CommandInteraction) {
+    const pageOption = interaction.options.get("page");
+
+    const page = !isNaN(Number(pageOption?.value)) ? Number(pageOption?.value) : 1;
+
+    const result = await EffectHelper.GenerateEffectEmbed(interaction.user.id, page);
+
+    await interaction.reply({
+        embeds: [ result.embed ],
+        components: [ result.row ],
+    });
+}

--- a/src/commands/effects/Use.ts
+++ b/src/commands/effects/Use.ts
@@ -1,0 +1,62 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, CommandInteraction, EmbedBuilder } from "discord.js";
+import { EffectDetails } from "../../constants/EffectDetails";
+import AppLogger from "../../client/appLogger";
+import EffectHelper from "../../helpers/EffectHelper";
+import TimeLengthInput from "../../helpers/TimeLengthInput";
+import EmbedColours from "../../constants/EmbedColours";
+
+export default async function Use(interaction: CommandInteraction) {
+    const id = interaction.options.get("id", true).value!.toString();
+
+    const effectDetail = EffectDetails.get(id);
+
+    if (!effectDetail) {
+        AppLogger.LogWarn("Commands/Effects", `Unable to find effect details for ${id}`);
+
+        await interaction.reply("Unable to find effect!");
+        return;
+    }
+
+    const canUseEffect = await EffectHelper.CanUseEffect(interaction.user.id, id);
+
+    if (!canUseEffect) {
+        await interaction.reply("Unable to use effect! Please make sure you have it in your inventory and is not on cooldown");
+        return;
+    }
+
+    const timeLengthInput = TimeLengthInput.ConvertFromMilliseconds(effectDetail.duration);
+
+    const embed = new EmbedBuilder()
+        .setTitle("Effect Confirmation")
+        .setDescription("Would you like to use this effect?")
+        .setColor(EmbedColours.Ok)
+        .addFields([
+            {
+                name: "Effect",
+                value: effectDetail.friendlyName,
+                inline: true,
+            },
+            {
+                name: "Length",
+                value: timeLengthInput.GetLengthShort(),
+                inline: true,
+            },
+        ]);
+
+    const row = new ActionRowBuilder<ButtonBuilder>()
+        .addComponents([
+            new ButtonBuilder()
+                .setLabel("Confirm")
+                .setCustomId(`effects use confirm ${effectDetail.id}`)
+                .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder()
+                .setLabel("Cancel")
+                .setCustomId(`effects use cancel ${effectDetail.id}`)
+                .setStyle(ButtonStyle.Danger),
+        ]);
+
+    await interaction.reply({
+        embeds: [ embed ],
+        components: [ row ],
+    });
+}

--- a/src/constants/EffectDetails.ts
+++ b/src/constants/EffectDetails.ts
@@ -17,3 +17,7 @@ class EffectDetail {
 export const EffectDetails = new Map<string, EffectDetail>([
     [ "unclaimed", new EffectDetail("unclaimed", "Unclaimed Chance Up", 10 * 60 * 1000, 100, 3 * 60 * 60 * 1000) ],
 ]);
+
+export const EffectChoices = [
+    { name: "Unclaimed Chance Up", value: "unclaimed" },
+];

--- a/tests/__functions__/discord.js/GenerateButtonInteractionMock.ts
+++ b/tests/__functions__/discord.js/GenerateButtonInteractionMock.ts
@@ -17,5 +17,7 @@ export default function GenerateButtonInteractionMock(): ButtonInteraction {
             id: "userId",
         },
         customId: "customId",
+        update: jest.fn(),
+        reply: jest.fn(),
     };
 }

--- a/tests/__functions__/discord.js/GenerateCommandInteractionMock.ts
+++ b/tests/__functions__/discord.js/GenerateCommandInteractionMock.ts
@@ -1,0 +1,12 @@
+import { CommandInteraction } from "../../__types__/discord.js";
+
+export default function GenerateCommandInteractionMock(options?: {
+    subcommand?: string,
+}): CommandInteraction {
+    return {
+        isChatInputCommand: jest.fn().mockReturnValue(true),
+        options: {
+            getSubcommand: jest.fn().mockReturnValue(options?.subcommand),
+        },
+    };
+}

--- a/tests/__types__/discord.js.ts
+++ b/tests/__types__/discord.js.ts
@@ -15,3 +15,10 @@ export type ButtonInteraction = {
     } | null,
     customId: string,
 }
+
+export type CommandInteraction = {
+    isChatInputCommand: jest.Func,
+    options: {
+        getSubcommand: jest.Func,
+    },
+}

--- a/tests/__types__/discord.js.ts
+++ b/tests/__types__/discord.js.ts
@@ -14,6 +14,8 @@ export type ButtonInteraction = {
         id: string,
     } | null,
     customId: string,
+    update: jest.Func,
+    reply: jest.Func,
 }
 
 export type CommandInteraction = {

--- a/tests/buttonEvents/Effects.test.ts
+++ b/tests/buttonEvents/Effects.test.ts
@@ -49,6 +49,8 @@ test("GIVEN action is use, EXPECT use function to be called", async () => {
     expect(List).not.toHaveBeenCalled();
 });
 
+test.todo("GIVEN action is buy, EXPECT buy function to be called");
+
 test("GIVEN action is invalid, EXPECT nothing to be called", async () => {
     // Arrange
     interaction.customId = "effects invalid";

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -1,0 +1,7 @@
+describe("Execute", () => {
+    test.todo("GIVEN subaction is confirm, EXPECT confirm function executed");
+
+    test.todo("GIVEN subaction is cancel, EXPECT cancel function executed");
+
+    test.todo("GIVEN subaction is invalid, EXPECT error logged");
+});

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -5,9 +5,11 @@ import { ButtonInteraction as ButtonInteractionType } from "../../__types__/disc
 import AppLogger from "../../../src/client/appLogger";
 import EffectHelper from "../../../src/helpers/EffectHelper";
 import EmbedColours from "../../../src/constants/EmbedColours";
+import User from "../../../src/database/entities/app/User";
 
 jest.mock("../../../src/client/appLogger");
 jest.mock("../../../src/helpers/EffectHelper");
+jest.mock("../../../src/database/entities/app/User");
 
 let interaction: ButtonInteractionType;
 
@@ -81,13 +83,23 @@ describe("Execute", () => {
 });
 
 describe("Confirm", () => {
+    let user: User;
+
     beforeEach(() => {
         interaction.customId += " confirm";
+
+        user = {
+            Currency: 1000,
+            Save: jest.fn(),
+            RemoveCurrency: jest.fn(),
+        } as unknown as User;
+
+        (User.FetchOneById as jest.Mock).mockResolvedValue(user);
     });
 
     test("EXPECT success embed generated", async () => {
         // Assert
-        interaction.customId += " id 1";
+        interaction.customId += " unclaimed 1";
 
         const embed = {
             id: "embed",
@@ -114,7 +126,7 @@ describe("Confirm", () => {
         });
 
         expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledTimes(1);
-        expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledWith("userId", "id", 1, true);
+        expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledWith("userId", "unclaimed", 1, true);
 
         expect(embed.setColor).toHaveBeenCalledTimes(1);
         expect(embed.setColor).toHaveBeenCalledWith(EmbedColours.Success);
@@ -124,6 +136,18 @@ describe("Confirm", () => {
 
         expect(interaction.reply).not.toHaveBeenCalled();
         expect(AppLogger.LogError).not.toHaveBeenCalled();
+
+        expect(User.FetchOneById).toHaveBeenCalledTimes(1);
+        expect(User.FetchOneById).toHaveBeenCalledWith(User, "userId");
+
+        expect(user.RemoveCurrency).toHaveBeenCalledTimes(1);
+        expect(user.RemoveCurrency).toHaveBeenCalledWith(100);
+
+        expect(user.Save).toHaveBeenCalledTimes(1);
+        expect(user.Save).toHaveBeenCalledWith(User, user);
+
+        expect(EffectHelper.AddEffectToUserInventory).toHaveBeenCalledTimes(1);
+        expect(EffectHelper.AddEffectToUserInventory).toHaveBeenCalledWith("userId", "unclaimed", 1);
     });
 
     test("GIVEN id is not supplied, EXPECT error", async () => {
@@ -156,7 +180,7 @@ describe("Confirm", () => {
 
     test("GIVEN quantity is not supplied, EXPECT error", async () => {
         // Assert
-        interaction.customId += " id";
+        interaction.customId += " unclaimed";
 
         const embed = {
             id: "embed",
@@ -186,7 +210,7 @@ describe("Confirm", () => {
 
     test("GIVEN quantity is not a number, EXPECT error", async () => {
         // Assert
-        interaction.customId += " id invalid";
+        interaction.customId += " unclaimed invalid";
 
         const embed = {
             id: "embed",
@@ -216,7 +240,7 @@ describe("Confirm", () => {
 
     test("GIVEN quantity is 0, EXPECT error", async () => {
         // Assert
-        interaction.customId += " id 0";
+        interaction.customId += " unclaimed 0";
 
         const embed = {
             id: "embed",
@@ -244,13 +268,48 @@ describe("Confirm", () => {
         expect(interaction.update).not.toHaveBeenCalled();
     });
 
-    test.todo("GIVEN user is not found, EXPECT error");
+    test("GIVEN user is not found, EXPECT error", async () => {
+        // Assert
+        interaction.customId += " unclaimed 1";
 
-    test.todo("GIVEN user does not have enough currency, EXPECT error");
+        (User.FetchOneById as jest.Mock).mockResolvedValue(undefined);
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy Confirm", "Unable to find user");
+
+        expect(EffectHelper.AddEffectToUserInventory).not.toHaveBeenCalled();
+
+        expect(interaction.update).not.toHaveBeenCalled();
+        expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN user does not have enough currency, EXPECT error", async () => {
+        // Assert
+        interaction.customId += " unclaimed 1";
+
+        user.Currency = 0;
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(interaction.reply).toHaveBeenCalledTimes(1);
+        expect(interaction.reply).toHaveBeenCalledWith("You don't have enough currency to buy this! You have `0 Currency` and need `100 Currency`!");
+        
+        expect(EffectHelper.AddEffectToUserInventory).not.toHaveBeenCalled();
+
+        expect(interaction.update).not.toHaveBeenCalled();
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
 
     test("GIVEN GenerateEffectBuyEmbed returns with a string, EXPECT error replied", async () => {
         // Assert
-        interaction.customId += " id 1";
+        interaction.customId += " unclaimed 1";
         
         (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue("Test error");
 

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -151,21 +151,6 @@ describe("Confirm", () => {
     });
 
     test("GIVEN id is not supplied, EXPECT error", async () => {
-        // Assert
-        const embed = {
-            id: "embed",
-            setColor: jest.fn(),
-            setFooter: jest.fn(),
-        };
-        const row = {
-            id: "row",
-        };
-        
-        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
-            embed,
-            row,
-        });
-
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
 
@@ -181,20 +166,6 @@ describe("Confirm", () => {
     test("GIVEN quantity is not supplied, EXPECT error", async () => {
         // Assert
         interaction.customId += " unclaimed";
-
-        const embed = {
-            id: "embed",
-            setColor: jest.fn(),
-            setFooter: jest.fn(),
-        };
-        const row = {
-            id: "row",
-        };
-        
-        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
-            embed,
-            row,
-        });
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
@@ -212,20 +183,6 @@ describe("Confirm", () => {
         // Assert
         interaction.customId += " unclaimed invalid";
 
-        const embed = {
-            id: "embed",
-            setColor: jest.fn(),
-            setFooter: jest.fn(),
-        };
-        const row = {
-            id: "row",
-        };
-        
-        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
-            embed,
-            row,
-        });
-
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
 
@@ -241,20 +198,6 @@ describe("Confirm", () => {
     test("GIVEN quantity is 0, EXPECT error", async () => {
         // Assert
         interaction.customId += " unclaimed 0";
-
-        const embed = {
-            id: "embed",
-            setColor: jest.fn(),
-            setFooter: jest.fn(),
-        };
-        const row = {
-            id: "row",
-        };
-        
-        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
-            embed,
-            row,
-        });
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -16,59 +16,15 @@ let interaction: ButtonInteractionType;
 beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.spyOn(Buy as any, "Confirm")
-        .mockRestore();
-    jest.spyOn(Buy as any, "Cancel")
-        .mockRestore();
-
     interaction = GenerateButtonInteractionMock();
     interaction.customId = "effects buy";
 
 });
 
 describe("Execute", () => {
-    test("GIVEN subaction is confirm, EXPECT confirm function executed", async () => {
-        // Arrange
-        interaction.customId += " confirm";
-
-        const confirmSpy = jest.spyOn(Buy as any, "Confirm")
-            .mockImplementation();
-
-        // Act
-        await Buy.Execute(interaction as unknown as ButtonInteraction);
-
-        // Assert
-        expect(confirmSpy).toHaveBeenCalledTimes(1);
-        expect(confirmSpy).toHaveBeenCalledWith(interaction);
-
-        expect(AppLogger.LogError).not.toHaveBeenCalled();
-    });
-
-    test("GIVEN subaction is cancel, EXPECT cancel function executed", async () => {
-        // Arrange
-        interaction.customId += " cancel";
-
-        const cancelSpy = jest.spyOn(Buy as any, "Cancel")
-            .mockImplementation();
-
-        // Act
-        await Buy.Execute(interaction as unknown as ButtonInteraction);
-
-        // Assert
-        expect(cancelSpy).toHaveBeenCalledTimes(1)
-        expect(cancelSpy).toHaveBeenCalledWith(interaction);
-
-        expect(AppLogger.LogError).not.toHaveBeenCalled();
-    });
-
     test("GIVEN subaction is invalid, EXPECT error logged", async () => {
         // Arrange
         interaction.customId += " invalid";
-
-        const confirmSpy = jest.spyOn(Buy as any, "Confirm")
-            .mockImplementation();
-        const cancelSpy = jest.spyOn(Buy as any, "Cancel")
-            .mockImplementation();
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
@@ -76,9 +32,6 @@ describe("Execute", () => {
         // Assert
         expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
         expect(AppLogger.LogError).toHaveBeenCalledWith("Buy", "Unknown subaction, effects invalid");
-
-        expect(confirmSpy).not.toHaveBeenCalled();
-        expect(cancelSpy).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -1,7 +1,69 @@
+import {ButtonInteraction} from "discord.js";
+import Buy from "../../../src/buttonEvents/Effects/Buy";
+import GenerateButtonInteractionMock from "../../__functions__/discord.js/GenerateButtonInteractionMock";
+import { ButtonInteraction as ButtonInteractionType } from "../../__types__/discord.js";
+import AppLogger from "../../../src/client/appLogger";
+
+jest.mock("../../../src/client/appLogger");
+
+let interaction: ButtonInteractionType;
+
+beforeEach(() => {
+    jest.resetAllMocks();
+
+    interaction = GenerateButtonInteractionMock();
+    interaction.customId = "effects buy";
+
+});
+
 describe("Execute", () => {
-    test.todo("GIVEN subaction is confirm, EXPECT confirm function executed");
+    test("GIVEN subaction is confirm, EXPECT confirm function executed", async () => {
+        // Arrange
+        interaction.customId += " confirm";
 
-    test.todo("GIVEN subaction is cancel, EXPECT cancel function executed");
+        const confirmSpy = jest.spyOn(Buy as any, "Confirm");
 
-    test.todo("GIVEN subaction is invalid, EXPECT error logged");
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(confirmSpy).toHaveBeenCalledWith(interaction);
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN subaction is cancel, EXPECT cancel function executed", async () => {
+        // Arrange
+        interaction.customId += " cancel";
+
+        const cancelSpy = jest.spyOn(Buy as any, "Cancel");
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(cancelSpy).toHaveBeenCalledTimes(1);
+        expect(cancelSpy).toHaveBeenCalledWith(interaction);
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN subaction is invalid, EXPECT error logged", async () => {
+        // Arrange
+        interaction.customId += " invalid";
+
+        const confirmSpy = jest.spyOn(Buy as any, "Confirm");
+        const cancelSpy = jest.spyOn(Buy as any, "Cancel");
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy", "Unknown subaction, effects invalid");
+
+        expect(confirmSpy).not.toHaveBeenCalled();
+        expect(cancelSpy).not.toHaveBeenCalled();
+    });
 });

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -3,8 +3,10 @@ import Buy from "../../../src/buttonEvents/Effects/Buy";
 import GenerateButtonInteractionMock from "../../__functions__/discord.js/GenerateButtonInteractionMock";
 import { ButtonInteraction as ButtonInteractionType } from "../../__types__/discord.js";
 import AppLogger from "../../../src/client/appLogger";
+import EffectHelper from "../../../src/helpers/EffectHelper";
 
 jest.mock("../../../src/client/appLogger");
+jest.mock("../../../src/helpers/EffectHelper");
 
 let interaction: ButtonInteractionType;
 
@@ -21,7 +23,8 @@ describe("Execute", () => {
         // Arrange
         interaction.customId += " confirm";
 
-        const confirmSpy = jest.spyOn(Buy as any, "Confirm");
+        const confirmSpy = jest.spyOn(Buy as any, "Confirm")
+            .mockImplementation();
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
@@ -37,13 +40,14 @@ describe("Execute", () => {
         // Arrange
         interaction.customId += " cancel";
 
-        const cancelSpy = jest.spyOn(Buy as any, "Cancel");
+        const cancelSpy = jest.spyOn(Buy as any, "Cancel")
+            .mockImplementation();
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
 
         // Assert
-        expect(cancelSpy).toHaveBeenCalledTimes(1);
+        expect(cancelSpy).toHaveBeenCalledTimes(1)
         expect(cancelSpy).toHaveBeenCalledWith(interaction);
 
         expect(AppLogger.LogError).not.toHaveBeenCalled();
@@ -53,8 +57,10 @@ describe("Execute", () => {
         // Arrange
         interaction.customId += " invalid";
 
-        const confirmSpy = jest.spyOn(Buy as any, "Confirm");
-        const cancelSpy = jest.spyOn(Buy as any, "Cancel");
+        const confirmSpy = jest.spyOn(Buy as any, "Confirm")
+            .mockImplementation();
+        const cancelSpy = jest.spyOn(Buy as any, "Cancel")
+            .mockImplementation();
 
         // Act
         await Buy.Execute(interaction as unknown as ButtonInteraction);
@@ -66,4 +72,53 @@ describe("Execute", () => {
         expect(confirmSpy).not.toHaveBeenCalled();
         expect(cancelSpy).not.toHaveBeenCalled();
     });
+});
+
+describe("Confirm", () => {
+    beforeEach(() => {
+        interaction.customId += " confirm";
+    });
+
+    test("EXPECT success embed generated", async () => {
+        // Assert
+        interaction.customId += " id 1";
+
+        const embed = {
+            id: "embed",
+        };
+        const row = {
+            id: "row",
+        };
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
+            embed,
+            row,
+        });
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(interaction.update).toHaveBeenCalledTimes(1);
+        expect(interaction.update).toHaveBeenCalledWith({
+            embeds: [ embed ],
+            components: [ row ],
+        });
+
+        expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledTimes(1);
+        expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledWith("userId", "id", 1, true);
+
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test.todo("GIVEN id is not supplied, EXPECT error");
+
+    test.todo("GIVEN quantity is not supplied, EXPECT error");
+
+    test.todo("GIVEN quantity is not a number, EXPECT error");
+
+    test.todo("GIVEN quantity is 0, EXPECT error");
+
+    test.todo("GIVEN GenerateEffectBuyEmbed returns with a string, EXPECT error replied");
 });

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -244,6 +244,10 @@ describe("Confirm", () => {
         expect(interaction.update).not.toHaveBeenCalled();
     });
 
+    test.todo("GIVEN user is not found, EXPECT error");
+
+    test.todo("GIVEN user does not have enough currency, EXPECT error");
+
     test("GIVEN GenerateEffectBuyEmbed returns with a string, EXPECT error replied", async () => {
         // Assert
         interaction.customId += " id 1";

--- a/tests/buttonEvents/Effects/Buy.test.ts
+++ b/tests/buttonEvents/Effects/Buy.test.ts
@@ -4,6 +4,7 @@ import GenerateButtonInteractionMock from "../../__functions__/discord.js/Genera
 import { ButtonInteraction as ButtonInteractionType } from "../../__types__/discord.js";
 import AppLogger from "../../../src/client/appLogger";
 import EffectHelper from "../../../src/helpers/EffectHelper";
+import EmbedColours from "../../../src/constants/EmbedColours";
 
 jest.mock("../../../src/client/appLogger");
 jest.mock("../../../src/helpers/EffectHelper");
@@ -12,6 +13,11 @@ let interaction: ButtonInteractionType;
 
 beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.spyOn(Buy as any, "Confirm")
+        .mockRestore();
+    jest.spyOn(Buy as any, "Cancel")
+        .mockRestore();
 
     interaction = GenerateButtonInteractionMock();
     interaction.customId = "effects buy";
@@ -85,6 +91,8 @@ describe("Confirm", () => {
 
         const embed = {
             id: "embed",
+            setColor: jest.fn(),
+            setFooter: jest.fn(),
         };
         const row = {
             id: "row",
@@ -108,17 +116,150 @@ describe("Confirm", () => {
         expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledTimes(1);
         expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledWith("userId", "id", 1, true);
 
+        expect(embed.setColor).toHaveBeenCalledTimes(1);
+        expect(embed.setColor).toHaveBeenCalledWith(EmbedColours.Success);
+
+        expect(embed.setFooter).toHaveBeenCalledTimes(1);
+        expect(embed.setFooter).toHaveBeenCalledWith({ text: "Purchased" });
+
         expect(interaction.reply).not.toHaveBeenCalled();
         expect(AppLogger.LogError).not.toHaveBeenCalled();
     });
 
-    test.todo("GIVEN id is not supplied, EXPECT error");
+    test("GIVEN id is not supplied, EXPECT error", async () => {
+        // Assert
+        const embed = {
+            id: "embed",
+            setColor: jest.fn(),
+            setFooter: jest.fn(),
+        };
+        const row = {
+            id: "row",
+        };
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
+            embed,
+            row,
+        });
 
-    test.todo("GIVEN quantity is not supplied, EXPECT error");
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
 
-    test.todo("GIVEN quantity is not a number, EXPECT error");
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy Confirm", "Not enough parameters");
 
-    test.todo("GIVEN quantity is 0, EXPECT error");
+        expect(EffectHelper.GenerateEffectBuyEmbed).not.toHaveBeenCalled();
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(interaction.update).not.toHaveBeenCalled();
+    });
 
-    test.todo("GIVEN GenerateEffectBuyEmbed returns with a string, EXPECT error replied");
+    test("GIVEN quantity is not supplied, EXPECT error", async () => {
+        // Assert
+        interaction.customId += " id";
+
+        const embed = {
+            id: "embed",
+            setColor: jest.fn(),
+            setFooter: jest.fn(),
+        };
+        const row = {
+            id: "row",
+        };
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
+            embed,
+            row,
+        });
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy Confirm", "Not enough parameters");
+
+        expect(EffectHelper.GenerateEffectBuyEmbed).not.toHaveBeenCalled();
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(interaction.update).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN quantity is not a number, EXPECT error", async () => {
+        // Assert
+        interaction.customId += " id invalid";
+
+        const embed = {
+            id: "embed",
+            setColor: jest.fn(),
+            setFooter: jest.fn(),
+        };
+        const row = {
+            id: "row",
+        };
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
+            embed,
+            row,
+        });
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy Confirm", "Invalid number");
+
+        expect(EffectHelper.GenerateEffectBuyEmbed).not.toHaveBeenCalled();
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(interaction.update).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN quantity is 0, EXPECT error", async () => {
+        // Assert
+        interaction.customId += " id 0";
+
+        const embed = {
+            id: "embed",
+            setColor: jest.fn(),
+            setFooter: jest.fn(),
+        };
+        const row = {
+            id: "row",
+        };
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue({
+            embed,
+            row,
+        });
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Buy Confirm", "Invalid number");
+
+        expect(EffectHelper.GenerateEffectBuyEmbed).not.toHaveBeenCalled();
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(interaction.update).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN GenerateEffectBuyEmbed returns with a string, EXPECT error replied", async () => {
+        // Assert
+        interaction.customId += " id 1";
+        
+        (EffectHelper.GenerateEffectBuyEmbed as jest.Mock).mockResolvedValue("Test error");
+
+        // Act
+        await Buy.Execute(interaction as unknown as ButtonInteraction);
+
+        // Assert
+        expect(interaction.reply).toHaveBeenCalledTimes(1);
+        expect(interaction.reply).toHaveBeenCalledWith("Test error");
+
+        expect(EffectHelper.GenerateEffectBuyEmbed).toHaveBeenCalledTimes(1);
+
+        expect(interaction.update).not.toHaveBeenCalled();
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
 });

--- a/tests/buttonEvents/Effects/List.test.ts
+++ b/tests/buttonEvents/Effects/List.test.ts
@@ -10,7 +10,7 @@ let interaction: ReturnType<typeof mock<ButtonInteraction>>;
 beforeEach(() => {
     jest.resetAllMocks();
 
-    (EffectHelper.GenerateEffectEmbed as jest.Mock).mockResolvedValue({
+    (EffectHelper.GenerateEffectListEmbed as jest.Mock).mockResolvedValue({
         embed: mock<EmbedBuilder>(),
         row: mock<ActionRowBuilder<ButtonBuilder>>(),
     });
@@ -31,7 +31,7 @@ test("GIVEN pageOption is NOT a number, EXPECT error", async () => {
     expect(interaction.reply).toHaveBeenCalledTimes(1);
     expect(interaction.reply).toHaveBeenCalledWith("Page option is not a valid number")
 
-    expect(EffectHelper.GenerateEffectEmbed).not.toHaveBeenCalled();
+    expect(EffectHelper.GenerateEffectListEmbed).not.toHaveBeenCalled();
     expect(interaction.update).not.toHaveBeenCalled();
 });
 
@@ -43,8 +43,8 @@ test("GIVEN pageOption is a number, EXPECT interaction updated", async () => {
     await List(interaction);
 
     // Assert
-    expect(EffectHelper.GenerateEffectEmbed).toHaveBeenCalledTimes(1);
-    expect(EffectHelper.GenerateEffectEmbed).toHaveBeenCalledWith("userId", 1);
+    expect(EffectHelper.GenerateEffectListEmbed).toHaveBeenCalledTimes(1);
+    expect(EffectHelper.GenerateEffectListEmbed).toHaveBeenCalledWith("userId", 1);
 
     expect(interaction.update).toHaveBeenCalledTimes(1);
 });

--- a/tests/commands/__snapshots__/effects.test.ts.snap
+++ b/tests/commands/__snapshots__/effects.test.ts.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EXPECT CommandBuilder to be defined 1`] = `
+{
+  "contexts": undefined,
+  "default_member_permissions": undefined,
+  "default_permission": undefined,
+  "description": "Effects",
+  "description_localizations": undefined,
+  "dm_permission": undefined,
+  "integration_types": undefined,
+  "name": "effects",
+  "name_localizations": undefined,
+  "nsfw": undefined,
+  "options": [
+    {
+      "description": "List all effects I have",
+      "description_localizations": undefined,
+      "name": "list",
+      "name_localizations": undefined,
+      "options": [
+        {
+          "autocomplete": undefined,
+          "choices": undefined,
+          "description": "The page number",
+          "description_localizations": undefined,
+          "max_value": undefined,
+          "min_value": 1,
+          "name": "page",
+          "name_localizations": undefined,
+          "required": false,
+          "type": 10,
+        },
+      ],
+      "type": 1,
+    },
+    {
+      "description": "Use an effect in your inventory",
+      "description_localizations": undefined,
+      "name": "use",
+      "name_localizations": undefined,
+      "options": [
+        {
+          "autocomplete": undefined,
+          "choices": [
+            {
+              "name": "Unclaimed Chance Up",
+              "name_localizations": undefined,
+              "value": "unclaimed",
+            },
+          ],
+          "description": "The effect id to use",
+          "description_localizations": undefined,
+          "max_length": undefined,
+          "min_length": undefined,
+          "name": "id",
+          "name_localizations": undefined,
+          "required": true,
+          "type": 3,
+        },
+      ],
+      "type": 1,
+    },
+    {
+      "description": "Buy more effects",
+      "description_localizations": undefined,
+      "name": "buy",
+      "name_localizations": undefined,
+      "options": [
+        {
+          "autocomplete": undefined,
+          "choices": [
+            {
+              "name": "Unclaimed Chance Up",
+              "name_localizations": undefined,
+              "value": "unclaimed",
+            },
+          ],
+          "description": "The effect id to buy",
+          "description_localizations": undefined,
+          "max_length": undefined,
+          "min_length": undefined,
+          "name": "id",
+          "name_localizations": undefined,
+          "required": true,
+          "type": 3,
+        },
+        {
+          "autocomplete": undefined,
+          "choices": undefined,
+          "description": "The amount to buy",
+          "description_localizations": undefined,
+          "max_value": undefined,
+          "min_value": 1,
+          "name": "quantity",
+          "name_localizations": undefined,
+          "required": false,
+          "type": 10,
+        },
+      ],
+      "type": 1,
+    },
+  ],
+  "type": 1,
+}
+`;

--- a/tests/commands/effects.test.ts
+++ b/tests/commands/effects.test.ts
@@ -1,0 +1,105 @@
+import Effects from "../../src/commands/effects";
+import List from "../../src/commands/effects/List";
+import Use from "../../src/commands/effects/Use";
+import Buy from "../../src/commands/effects/Buy";
+import AppLogger from "../../src/client/appLogger";
+import GenerateCommandInteractionMock from "../__functions__/discord.js/GenerateCommandInteractionMock";
+import { CommandInteraction } from "discord.js";
+
+jest.mock("../../src/commands/effects/List");
+jest.mock("../../src/commands/effects/Use");
+jest.mock("../../src/commands/effects/Buy");
+jest.mock("../../src/client/appLogger");
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test("EXPECT CommandBuilder to be defined", async () => {
+    // Act
+    const effects = new Effects();
+
+    // Assert
+    expect(effects.CommandBuilder).toMatchSnapshot();
+});
+
+describe("execute", () => {
+    test("GIVEN interaction subcommand is list, EXPECT buy function called", async () => {
+        // Arrange
+        const interaction = GenerateCommandInteractionMock({
+            subcommand: "list",
+        });
+
+        // Act
+        const effects = new Effects();
+        await effects.execute(interaction as unknown as CommandInteraction);
+
+        // Assert
+        expect(List).toHaveBeenCalledTimes(1);
+        expect(List).toHaveBeenCalledWith(interaction);
+
+        expect(Use).not.toHaveBeenCalled();
+        expect(Buy).not.toHaveBeenCalled();
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN interaction subcommand is use, EXPECT buy function called", async () => {
+        // Arrange
+        const interaction = GenerateCommandInteractionMock({
+            subcommand: "use",
+        });
+
+        // Act
+        const effects = new Effects();
+        await effects.execute(interaction as unknown as CommandInteraction);
+
+        // Assert
+        expect(Use).toHaveBeenCalledTimes(1);
+        expect(Use).toHaveBeenCalledWith(interaction);
+
+        expect(List).not.toHaveBeenCalled();
+        expect(Buy).not.toHaveBeenCalled();
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN interaction subcommand is buy, EXPECT buy function called", async () => {
+        // Arrange
+        const interaction = GenerateCommandInteractionMock({
+            subcommand: "buy",
+        });
+
+        // Act
+        const effects = new Effects();
+        await effects.execute(interaction as unknown as CommandInteraction);
+
+        // Assert
+        expect(Buy).toHaveBeenCalledTimes(1);
+        expect(Buy).toHaveBeenCalledWith(interaction);
+
+        expect(List).not.toHaveBeenCalled();
+        expect(Use).not.toHaveBeenCalled();
+
+        expect(AppLogger.LogError).not.toHaveBeenCalled();
+    });
+
+    test("GIVEN interaction subcommand is invalid, EXPECT error logged", async () => {
+        // Arrange
+        const interaction = GenerateCommandInteractionMock({
+            subcommand: "invalid",
+        });
+
+        // Act
+        const effects = new Effects();
+        await effects.execute(interaction as unknown as CommandInteraction);
+
+        // Assert
+        expect(AppLogger.LogError).toHaveBeenCalledTimes(1);
+        expect(AppLogger.LogError).toHaveBeenCalledWith("Commands/Effects", "Invalid subcommand: invalid");
+
+        expect(List).not.toHaveBeenCalled();
+        expect(Use).not.toHaveBeenCalled();
+        expect(Buy).not.toHaveBeenCalled();
+    });
+});

--- a/tests/commands/effects/Buy.test.ts
+++ b/tests/commands/effects/Buy.test.ts
@@ -1,6 +1,3 @@
-import Buy from "../../../src/commands/effects/Buy";
-import EffectHelper from "../../../src/helpers/EffectHelper";
-
 jest.mock("../../../src/helpers/EffectHelper");
 
 describe("Buy", () => {

--- a/tests/commands/effects/Buy.test.ts
+++ b/tests/commands/effects/Buy.test.ts
@@ -1,0 +1,12 @@
+import Buy from "../../../src/commands/effects/Buy";
+import EffectHelper from "../../../src/helpers/EffectHelper";
+
+jest.mock("../../../src/helpers/EffectHelper");
+
+describe("Buy", () => {
+    test.todo("GIVEN result returns a string, EXPECT interaction replied with string");
+
+    test.todo("GIVEN result returns an embed, EXPECT interaction replied with embed and row");
+
+    test.todo("GIVEN quantity option is not supplied, EXPECT quantity to default to 1");
+});

--- a/tests/helpers/EffectHelper.test.ts
+++ b/tests/helpers/EffectHelper.test.ts
@@ -3,7 +3,7 @@ import UserEffect from "../../src/database/entities/app/UserEffect";
 
 jest.mock("../../src/database/entities/app/UserEffect");
 
-describe("GenerateEffectEmbed", () => {
+describe("GenerateEffectListEmbed", () => {
     test("GIVEN user has an effect, EXPECT detailed embed to be returned", async () => {
         // Arrange
         (UserEffect.FetchAllByUserIdPaginated as jest.Mock).mockResolvedValue([
@@ -17,7 +17,7 @@ describe("GenerateEffectEmbed", () => {
         ]);
 
         // Act
-        const result = await EffectHelper.GenerateEffectEmbed("userId", 1);
+        const result = await EffectHelper.GenerateEffectListEmbed("userId", 1);
 
         // Assert
         expect(result).toMatchSnapshot();
@@ -43,7 +43,7 @@ describe("GenerateEffectEmbed", () => {
         ]);
 
         // Act
-        const result = await EffectHelper.GenerateEffectEmbed("userId", 1);
+        const result = await EffectHelper.GenerateEffectListEmbed("userId", 1);
 
         // Assert
         expect(result).toMatchSnapshot();
@@ -69,7 +69,7 @@ describe("GenerateEffectEmbed", () => {
         ]);
 
         // Act
-        const result = await EffectHelper.GenerateEffectEmbed("userId", 2);
+        const result = await EffectHelper.GenerateEffectListEmbed("userId", 2);
 
         // Assert
         expect(result).toMatchSnapshot();
@@ -83,7 +83,7 @@ describe("GenerateEffectEmbed", () => {
         ]);
 
         // Act
-        const result = await EffectHelper.GenerateEffectEmbed("userId", 1);
+        const result = await EffectHelper.GenerateEffectListEmbed("userId", 1);
 
         // Assert
         expect(result).toMatchSnapshot();
@@ -107,9 +107,21 @@ describe("GenerateEffectEmbed", () => {
         });
 
         // Act
-        const result = await EffectHelper.GenerateEffectEmbed("userId", 1);
+        const result = await EffectHelper.GenerateEffectListEmbed("userId", 1);
 
         // Assert
         expect(result).toMatchSnapshot();
     });
+});
+
+describe("GenerateEffectBuyEmbed", () => {
+    test.todo("GIVEN Effect Details are not found, EXPECT error");
+
+    test.todo("GIVEN user is not in database, EXPECT blank user created");
+
+    test.todo("GIVEN user does not have enough currency, EXPECT error");
+
+    test.todo("GIVEN user does have enough currency, EXPECT embed returned");
+
+    test.todo("GIVEN disabled boolean is true, EXPECT buttons to be disabled");
 });

--- a/tests/helpers/__snapshots__/EffectHelper.test.ts.snap
+++ b/tests/helpers/__snapshots__/EffectHelper.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GenerateEffectEmbed GIVEN there is an active effect, EXPECT field added 1`] = `
+exports[`GenerateEffectListEmbed GIVEN there is an active effect, EXPECT field added 1`] = `
 {
   "embed": {
     "color": 3166394,
@@ -47,7 +47,7 @@ exports[`GenerateEffectEmbed GIVEN there is an active effect, EXPECT field added
 }
 `;
 
-exports[`GenerateEffectEmbed GIVEN user does NOT have an effect, EXPECT empty embed to be returned 1`] = `
+exports[`GenerateEffectListEmbed GIVEN user does NOT have an effect, EXPECT empty embed to be returned 1`] = `
 {
   "embed": {
     "color": 3166394,
@@ -82,7 +82,7 @@ exports[`GenerateEffectEmbed GIVEN user does NOT have an effect, EXPECT empty em
 }
 `;
 
-exports[`GenerateEffectEmbed GIVEN user has an effect, EXPECT detailed embed to be returned 1`] = `
+exports[`GenerateEffectListEmbed GIVEN user has an effect, EXPECT detailed embed to be returned 1`] = `
 {
   "embed": {
     "color": 3166394,
@@ -117,7 +117,7 @@ exports[`GenerateEffectEmbed GIVEN user has an effect, EXPECT detailed embed to 
 }
 `;
 
-exports[`GenerateEffectEmbed GIVEN user has more than 1 page of effects, EXPECT pagination enabled 1`] = `
+exports[`GenerateEffectListEmbed GIVEN user has more than 1 page of effects, EXPECT pagination enabled 1`] = `
 {
   "embed": {
     "color": 3166394,
@@ -166,7 +166,7 @@ Unclaimed Chance Up x1",
 }
 `;
 
-exports[`GenerateEffectEmbed GIVEN user is on a page other than 1, EXPECT pagination enabled 1`] = `
+exports[`GenerateEffectListEmbed GIVEN user is on a page other than 1, EXPECT pagination enabled 1`] = `
 {
   "embed": {
     "color": 3166394,


### PR DESCRIPTION
# Description

- Create a command to generate an embed for the user to be able to buy more effects
- This embed will contain the details about the effect as well as 2 buttons; Confirm and Cancel
- The confirm button will call the button event to:
    - Remove the currency from the user
    - Give the user the effect to their inventory
- The cancel button will just disable the buttons, so the user can't accidentally use it if they don't want to.

#381

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Have created unit tests and tested locally

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that provde my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules